### PR TITLE
:bug: BSD-compatible terminal detection (fixes #3)

### DIFF
--- a/pkg/log/output_file.go
+++ b/pkg/log/output_file.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/octogo/log/internal/lib"
 	"github.com/octogo/log/pkg/level"
-	"golang.org/x/sys/unix"
+	"github.com/octogo/log/pkg/log/terminal"
 )
 
 // FileOutput implements an output that writes the logs to a file.
@@ -51,7 +51,7 @@ func (fOut FileOutput) Log(e Entry) (n int, err error) {
 	fOut.mu.Lock()
 	defer fOut.mu.Unlock()
 	if fOut.Wants(e.LevelLevel()) {
-		return fOut.File.WriteString(e.Formatted(fOut.format, !fOut.isTerminal()) + "\n")
+		return fOut.File.WriteString(e.Formatted(fOut.format, !terminal.IsTerminal(int(fOut.File.Fd()))) + "\n")
 	}
 	return 0, nil
 }
@@ -81,9 +81,4 @@ func (fOut FileOutput) Wants(lvl level.Level) bool {
 		}
 	}
 	return false
-}
-
-func (fOut FileOutput) isTerminal() bool {
-	_, err := unix.IoctlGetTermios(int(fOut.File.Fd()), unix.TCGETS)
-	return err == nil
 }

--- a/pkg/log/terminal/terminal_check_bsd.go
+++ b/pkg/log/terminal/terminal_check_bsd.go
@@ -1,0 +1,12 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TIOCGETA
+
+func IsTerminal(fd int) bool {
+	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	return err == nil
+}

--- a/pkg/log/terminal/terminal_check_unix.go
+++ b/pkg/log/terminal/terminal_check_unix.go
@@ -1,0 +1,12 @@
+// +build linux aix
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+const ioctlReadTermios = unix.TCGETS
+
+func IsTerminal(fd int) bool {
+	_, err := unix.IoctlGetTermios(fd, ioctlReadTermios)
+	return err == nil
+}


### PR DESCRIPTION
- introduce build constraints for BSD and UNIX
  - use BSD's unix.TIOCGETA
  - use UNIX' unix.TCGETS

:sparkling_heart: Thanks to @bbusse for reporting!